### PR TITLE
Fixing a syntax bug that pops up for some versions of Python

### DIFF
--- a/ripser/ripser.py
+++ b/ripser/ripser.py
@@ -133,11 +133,11 @@ def ripser(
     n_points = dm.shape[0]
 
     if sparse.issparse(dm):
-        coo = sparse.coo_matrix.astype(dm.tocoo(), dtype=np.float32)
+        coo = dm.tocoo()
         res = DRFDMSparse(
             coo.row,
             coo.col,
-            coo.data,
+            np.array(coo.data, dtype=np.float32),
             n_points,
             maxdim,
             thresh,


### PR DESCRIPTION
I couldn't replicate this bug in our continuous integration or on my computer, but a colleague was getting a syntax error with sparse matrices and this fixed it