### PR TITLE
Fixingfullbirthtimes

### DIFF
--- a/ripser/ripser.py
+++ b/ripser/ripser.py
@@ -131,6 +131,13 @@ def ripser(
         raise Exception("Distance matrix is not square")
     dm = X
     n_points = dm.shape[0]
+    if not sparse.issparse(dm) and \
+        np.sum(np.abs(dm.diagonal()) > 0) > 0:
+        # If any of the diagonal elements are nonzero,
+        # convert to sparse format, because currently
+        # that's the only format that handles nonzero
+        # births
+        dm = sparse.coo_matrix(dm)
 
     if sparse.issparse(dm):
         coo = dm.tocoo()

--- a/test/test_ripser.py
+++ b/test/test_ripser.py
@@ -127,4 +127,12 @@ class TestParams():
         I2 = rips['dgms'][2]
         assert(I2.shape[0] == 1)
         assert(np.allclose(1.0, I2[0, 1]))
-        
+    
+    def test_full_nonzerobirths(self):
+        D = np.array([[1.0, 3.0], [3.0, 2.0]])
+        h0 = ripser(D, distance_matrix=True, maxdim=0)['dgms'][0]
+        h0 = h0[np.argsort(h0[:, 0]), :]
+        assert(h0[0, 0] == 1)
+        assert(np.isinf(h0[0, 1]))
+        assert(h0[1, 0] == 2)
+        assert(h0[1, 1] == 3)


### PR DESCRIPTION
Creating a patch to handle the case where vertices have nonzero birthtimes represented by nonzero diagonal entries in dense matrices, which isn't supported in the C code by default.  To fix this with minimum additional code, I simply convert the matrix to a sparse matrix in this case