### PR TITLE
Compile args work on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Dependencies:
 
 **Windows users:** If you are using a Windows machine, you will also need to install [MinGW](http://www.mingw.org) on your system.
 
+**Mac users:** Updating your Xcode and Xcode command line tools will probably fix any issues you have with installation.
+
 Cython should be the only library required before installation.  To install, type the following commands into your environment:
 
 ```

--- a/ripser/ripser.py
+++ b/ripser/ripser.py
@@ -261,9 +261,9 @@ def ripser(
     if sparse.issparse(dm):
         coo = dm.tocoo()
         res = DRFDMSparse(
-            coo.row,
-            coo.col,
-            np.array(coo.data, dtype=np.float32),
+            coo.row.astype(dtype=np.int32, order="C"),
+            coo.col.astype(dtype=np.int32, order="C"),
+            np.array(coo.data, dtype=np.float32, order="C"),
             n_points,
             maxdim,
             thresh,

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     author="Chris Tralie, Nathaniel Saul",
-    author_email="chris.tralie@gmail.com, nathaniel.saul@wsu.edu",
+    author_email="chris.tralie@gmail.com, nat@riverasaul.com",
     url="https://ripser.scikit-tda.org",
     license='MIT',
     packages=['ripser'],

--- a/setup.py
+++ b/setup.py
@@ -46,11 +46,9 @@ extra_compile_args = ["-Ofast", "-D_hypot=hypot"]
 extra_link_args = []
 
 if platform.system() == "Windows":
-    # extra_compile_args.extend([
-    #     "/std:c++latest", 
-    #     "/EHsc"
-    # ])
-    pass
+    extra_compile_args.extend([
+        '-std=c++11'
+    ])
 elif platform.system() == "Darwin":
     extra_compile_args.extend([
         '-std=c++11', 


### PR DESCRIPTION
The compile arguments were not working on windows build (see the appveyor history).

This PR fixes the compile args, and fixes a bug that shows up on Windows 32 bit systems.