### PR TITLE
Improve Windows compatibility.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,44 +1,43 @@
 build: false
 
-environment: 
+environment:
   matrix:
     - PYTHON_VERSION: 3.5
       MINICONDA: C:\Miniconda3
-      
+
     - PYTHON_VERSION: 3.5
       MINICONDA: C:\Miniconda3-x64
-      
+
     - PYTHON_VERSION: 3.6
       MINICONDA: C:\Miniconda3
-      
+
     - PYTHON_VERSION: 3.6
       MINICONDA: C:\Miniconda3-x64
-      
+
     - PYTHON_VERSION: 3.7
       MINICONDA: C:\Miniconda3
-      
+
     - PYTHON_VERSION: 3.7
       MINICONDA: C:\Miniconda3-x64
 
-init: 
+init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"
 
-install: 
-  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%" 
+install:
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - python --version
   - python -c "import sys,platform,struct;print(sys.platform, platform.machine(), struct.calcsize('P') * 8, )"
-  - conda config --set always_yes yes --set changeps1 no 
-  - conda update -q conda 
-  - conda info -a 
-  - "conda create -q -n test-environment 
-  python=%PYTHON_VERSION% numpy pandas scipy matplotlib pytest" 
-  - activate test-environment 
-  - conda install libpython m2w64-toolchain cython
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - "conda create -q -n test-environment
+  python=%PYTHON_VERSION% numpy pandas scipy matplotlib pytest"
+  - activate test-environment
+  - conda install libpython cython
   - echo [build] > %CONDA_PREFIX%\Lib\distutils\distutils.cfg
-  - echo compiler = mingw32 >> %CONDA_PREFIX%\Lib\distutils\distutils.cfg
   - python setup.py install
 
-test_script: 
+test_script:
   - pytest .
 
 after_test:

--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -106,7 +106,6 @@ std::vector<coefficient_t> multiplicative_inverse_vector(const coefficient_t m) 
 }
 
 #ifdef USE_COEFFICIENTS
-PACK(
 struct entry_t {
 	index_t index : 8 * (sizeof(index_t) - sizeof(coefficient_t));
 	coefficient_t coefficient;
@@ -114,7 +113,7 @@ struct entry_t {
 	    : index(_index), coefficient(_coefficient) {}
 	entry_t(index_t _index) : index(_index), coefficient(1) {}
 	entry_t() : index(0), coefficient(1) {}
-});
+};
 
 //static_assert(sizeof(entry_t) == sizeof(index_t), "size of entry_t is not the same as index_t");
 

--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -248,7 +248,7 @@ public:
 	size_t size() const { return neighbors.size(); }
 };
 
-template <> void compressed_distance_matrix<LOWER_TRIANGULAR>::init_rows() {
+void compressed_distance_matrix<LOWER_TRIANGULAR>::init_rows() {
 	value_t* pointer = &distances[0];
 	for (size_t i = 1; i < size(); ++i) {
 		rows[i] = pointer;
@@ -256,7 +256,7 @@ template <> void compressed_distance_matrix<LOWER_TRIANGULAR>::init_rows() {
 	}
 }
 
-template <> void compressed_distance_matrix<UPPER_TRIANGULAR>::init_rows() {
+void compressed_distance_matrix<UPPER_TRIANGULAR>::init_rows() {
 	value_t* pointer = &distances[0] - 1;
 	for (size_t i = 0; i < size() - 1; ++i) {
 		rows[i] = pointer;
@@ -264,13 +264,11 @@ template <> void compressed_distance_matrix<UPPER_TRIANGULAR>::init_rows() {
 	}
 }
 
-template <>
 value_t compressed_distance_matrix<UPPER_TRIANGULAR>::operator()(const index_t i,
                                                                  const index_t j) const {
 	return i == j ? 0 : i > j ? rows[j][i] : rows[i][j];
 }
 
-template <>
 value_t compressed_distance_matrix<LOWER_TRIANGULAR>::operator()(const index_t i,
                                                                  const index_t j) const {
 	return i == j ? 0 : i < j ? rows[j][i] : rows[i][j];
@@ -816,7 +814,7 @@ public:
 	}
 };
 
-template <> class ripser<compressed_lower_distance_matrix>::simplex_coboundary_enumerator {
+class ripser<compressed_lower_distance_matrix>::simplex_coboundary_enumerator {
 private:
 	index_t idx_below, idx_above, v, k;
 	std::vector<index_t> vertices;
@@ -855,7 +853,7 @@ public:
 	}
 };
 
-template <> class ripser<sparse_distance_matrix>::simplex_coboundary_enumerator {
+class ripser<sparse_distance_matrix>::simplex_coboundary_enumerator {
 private:
 	const ripser& parent;
 
@@ -930,7 +928,7 @@ public:
 	}
 };
 
-template <> std::vector<diameter_index_t> ripser<compressed_lower_distance_matrix>::get_edges() {
+std::vector<diameter_index_t> ripser<compressed_lower_distance_matrix>::get_edges() {
 	std::vector<diameter_index_t> edges;
 	for (index_t index = binomial_coeff(n, 2); index-- > 0;) {
 		value_t diameter = compute_diameter(index, 1);
@@ -939,7 +937,7 @@ template <> std::vector<diameter_index_t> ripser<compressed_lower_distance_matri
 	return edges;
 }
 
-template <> std::vector<diameter_index_t> ripser<sparse_distance_matrix>::get_edges() {
+std::vector<diameter_index_t> ripser<sparse_distance_matrix>::get_edges() {
 	std::vector<diameter_index_t> edges;
 	for (index_t i = 0; i < n; ++i)
 		for (auto n : dist.neighbors[i]) {
@@ -949,17 +947,16 @@ template <> std::vector<diameter_index_t> ripser<sparse_distance_matrix>::get_ed
 	return edges;
 }
 
-template <> value_t ripser<compressed_lower_distance_matrix>::get_vertex_birth(index_t i) {
+value_t ripser<compressed_lower_distance_matrix>::get_vertex_birth(index_t i) {
 	//TODO: Dummy for now; nonzero vertex births are only done through
 	//sparse matrices at the moment
 	return 0.0;
 }
 
-template <> value_t ripser<sparse_distance_matrix>::get_vertex_birth(index_t i) {
+value_t ripser<sparse_distance_matrix>::get_vertex_birth(index_t i) {
 	return dist.vertex_births[i];
 }
 
-template <>
 void ripser<compressed_lower_distance_matrix>::assemble_columns_to_reduce(
     std::vector<diameter_index_t>& simplices, std::vector<diameter_index_t>& columns_to_reduce,
     hash_map<index_t, index_t>& pivot_column_index, index_t dim) {
@@ -978,7 +975,6 @@ void ripser<compressed_lower_distance_matrix>::assemble_columns_to_reduce(
 	          greater_diameter_or_smaller_index<diameter_index_t>());
 }
 
-template <>
 void ripser<sparse_distance_matrix>::assemble_columns_to_reduce(
     std::vector<diameter_index_t>& simplices, std::vector<diameter_index_t>& columns_to_reduce,
     hash_map<index_t, index_t>& pivot_column_index, index_t dim) {

--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -43,6 +43,7 @@ derivative works thereof, in binary and source code form.
 #include <cmath>
 #include <cstring>
 #include <fstream>
+#include <iterator>
 #include <iostream>
 #include <numeric>
 #include <queue>

--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -48,6 +48,7 @@ derivative works thereof, in binary and source code form.
 #include <queue>
 #include <sstream>
 #include <unordered_map>
+#include "ripser.hpp"
 
 
 /* Packing support for Windows */
@@ -279,14 +280,6 @@ value_t compressed_distance_matrix<LOWER_TRIANGULAR>::operator()(const index_t i
 
 typedef compressed_distance_matrix<LOWER_TRIANGULAR> compressed_lower_distance_matrix;
 typedef compressed_distance_matrix<UPPER_TRIANGULAR> compressed_upper_distance_matrix;
-
-
-template <typename DistanceMatrix> class ripser;
-template <> class ripser<compressed_lower_distance_matrix>::simplex_coboundary_enumerator;
-template <> class ripser<sparse_distance_matrix>::simplex_coboundary_enumerator;
-template <> void compressed_distance_matrix<LOWER_TRIANGULAR>::init_rows();
-template <> void compressed_distance_matrix<UPPER_TRIANGULAR>::init_rows();
-
 
 
 class union_find {

--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -57,6 +57,8 @@ derivative works thereof, in binary and source code form.
 #define PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))
 #endif
 
+
+template <typename DistanceMatrix> class ripser;
 template <> class ripser<compressed_lower_distance_matrix>::simplex_coboundary_enumerator;
 template <> class ripser<sparse_distance_matrix>::simplex_coboundary_enumerator;
 template <> void compressed_distance_matrix<LOWER_TRIANGULAR>::init_rows();

--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -57,6 +57,11 @@ derivative works thereof, in binary and source code form.
 #define PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))
 #endif
 
+template <> class ripser<compressed_lower_distance_matrix>::simplex_coboundary_enumerator;
+template <> class ripser<sparse_distance_matrix>::simplex_coboundary_enumerator;
+template <> void compressed_distance_matrix<LOWER_TRIANGULAR>::init_rows();
+template <> void compressed_distance_matrix<UPPER_TRIANGULAR>::init_rows();
+
 
 template <class Key, class T> class hash_map : public std::unordered_map<Key, T> {};
 typedef float value_t;

--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -48,7 +48,6 @@ derivative works thereof, in binary and source code form.
 #include <queue>
 #include <sstream>
 #include <unordered_map>
-#include "ripser.hpp"
 
 
 /* Disable packing for Windows */

--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -50,6 +50,14 @@ derivative works thereof, in binary and source code form.
 #include <unordered_map>
 
 
+/* Packing support for Windows */
+#if defined _WIN32
+#define PACK( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop) )
+#else
+#define PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))
+#endif
+
+
 template <class Key, class T> class hash_map : public std::unordered_map<Key, T> {};
 typedef float value_t;
 typedef int64_t index_t;
@@ -98,14 +106,15 @@ std::vector<coefficient_t> multiplicative_inverse_vector(const coefficient_t m) 
 }
 
 #ifdef USE_COEFFICIENTS
-struct __attribute__((packed)) entry_t {
+PACK(
+struct entry_t {
 	index_t index : 8 * (sizeof(index_t) - sizeof(coefficient_t));
 	coefficient_t coefficient;
 	entry_t(index_t _index, coefficient_t _coefficient)
 	    : index(_index), coefficient(_coefficient) {}
 	entry_t(index_t _index) : index(_index), coefficient(1) {}
 	entry_t() : index(0), coefficient(1) {}
-};
+});
 
 //static_assert(sizeof(entry_t) == sizeof(index_t), "size of entry_t is not the same as index_t");
 
@@ -208,7 +217,7 @@ public:
 
 	//Initialize from thresholded dense distance matrix
 	template <typename DistanceMatrix>
-	sparse_distance_matrix(const DistanceMatrix& mat, value_t threshold) : 
+	sparse_distance_matrix(const DistanceMatrix& mat, value_t threshold) :
 							neighbors(mat.size()), vertex_births(mat.size(), 0) {
 		for (size_t i = 0; i < size(); ++i) {
 			for (size_t j = 0; j < size(); ++j) {
@@ -219,7 +228,7 @@ public:
 		}
 	}
 	//Initialize from COO format
-	sparse_distance_matrix(int* I, int* J, float* V, int NEdges, int N, float threshold) : 
+	sparse_distance_matrix(int* I, int* J, float* V, int NEdges, int N, float threshold) :
 							neighbors(N), vertex_births(N, 0) {
 		int i, j;
 		value_t val;
@@ -944,7 +953,7 @@ template <> std::vector<diameter_index_t> ripser<sparse_distance_matrix>::get_ed
 template <> value_t ripser<compressed_lower_distance_matrix>::get_vertex_birth(index_t i) {
 	//TODO: Dummy for now; nonzero vertex births are only done through
 	//sparse matrices at the moment
-	return 0.0; 
+	return 0.0;
 }
 
 template <> value_t ripser<sparse_distance_matrix>::get_vertex_birth(index_t i) {

--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -248,7 +248,7 @@ public:
 	size_t size() const { return neighbors.size(); }
 };
 
-void compressed_distance_matrix<LOWER_TRIANGULAR>::init_rows() {
+template <> void compressed_distance_matrix<LOWER_TRIANGULAR>::init_rows() {
 	value_t* pointer = &distances[0];
 	for (size_t i = 1; i < size(); ++i) {
 		rows[i] = pointer;
@@ -256,7 +256,7 @@ void compressed_distance_matrix<LOWER_TRIANGULAR>::init_rows() {
 	}
 }
 
-void compressed_distance_matrix<UPPER_TRIANGULAR>::init_rows() {
+template <> void compressed_distance_matrix<UPPER_TRIANGULAR>::init_rows() {
 	value_t* pointer = &distances[0] - 1;
 	for (size_t i = 0; i < size() - 1; ++i) {
 		rows[i] = pointer;
@@ -264,11 +264,13 @@ void compressed_distance_matrix<UPPER_TRIANGULAR>::init_rows() {
 	}
 }
 
+template <>
 value_t compressed_distance_matrix<UPPER_TRIANGULAR>::operator()(const index_t i,
                                                                  const index_t j) const {
 	return i == j ? 0 : i > j ? rows[j][i] : rows[i][j];
 }
 
+template <>
 value_t compressed_distance_matrix<LOWER_TRIANGULAR>::operator()(const index_t i,
                                                                  const index_t j) const {
 	return i == j ? 0 : i < j ? rows[j][i] : rows[i][j];
@@ -814,7 +816,7 @@ public:
 	}
 };
 
-class ripser<compressed_lower_distance_matrix>::simplex_coboundary_enumerator {
+template <> class ripser<compressed_lower_distance_matrix>::simplex_coboundary_enumerator {
 private:
 	index_t idx_below, idx_above, v, k;
 	std::vector<index_t> vertices;
@@ -853,7 +855,7 @@ public:
 	}
 };
 
-class ripser<sparse_distance_matrix>::simplex_coboundary_enumerator {
+template <> class ripser<sparse_distance_matrix>::simplex_coboundary_enumerator {
 private:
 	const ripser& parent;
 
@@ -928,7 +930,7 @@ public:
 	}
 };
 
-std::vector<diameter_index_t> ripser<compressed_lower_distance_matrix>::get_edges() {
+template <> std::vector<diameter_index_t> ripser<compressed_lower_distance_matrix>::get_edges() {
 	std::vector<diameter_index_t> edges;
 	for (index_t index = binomial_coeff(n, 2); index-- > 0;) {
 		value_t diameter = compute_diameter(index, 1);
@@ -937,7 +939,7 @@ std::vector<diameter_index_t> ripser<compressed_lower_distance_matrix>::get_edge
 	return edges;
 }
 
-std::vector<diameter_index_t> ripser<sparse_distance_matrix>::get_edges() {
+template <> std::vector<diameter_index_t> ripser<sparse_distance_matrix>::get_edges() {
 	std::vector<diameter_index_t> edges;
 	for (index_t i = 0; i < n; ++i)
 		for (auto n : dist.neighbors[i]) {
@@ -947,16 +949,17 @@ std::vector<diameter_index_t> ripser<sparse_distance_matrix>::get_edges() {
 	return edges;
 }
 
-value_t ripser<compressed_lower_distance_matrix>::get_vertex_birth(index_t i) {
+template <> value_t ripser<compressed_lower_distance_matrix>::get_vertex_birth(index_t i) {
 	//TODO: Dummy for now; nonzero vertex births are only done through
 	//sparse matrices at the moment
 	return 0.0;
 }
 
-value_t ripser<sparse_distance_matrix>::get_vertex_birth(index_t i) {
+template <> value_t ripser<sparse_distance_matrix>::get_vertex_birth(index_t i) {
 	return dist.vertex_births[i];
 }
 
+template <>
 void ripser<compressed_lower_distance_matrix>::assemble_columns_to_reduce(
     std::vector<diameter_index_t>& simplices, std::vector<diameter_index_t>& columns_to_reduce,
     hash_map<index_t, index_t>& pivot_column_index, index_t dim) {
@@ -975,6 +978,7 @@ void ripser<compressed_lower_distance_matrix>::assemble_columns_to_reduce(
 	          greater_diameter_or_smaller_index<diameter_index_t>());
 }
 
+template <>
 void ripser<sparse_distance_matrix>::assemble_columns_to_reduce(
     std::vector<diameter_index_t>& simplices, std::vector<diameter_index_t>& columns_to_reduce,
     hash_map<index_t, index_t>& pivot_column_index, index_t dim) {

--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -829,7 +829,7 @@ private:
 
 public:
 	simplex_coboundary_enumerator(const diameter_entry_t _simplex, index_t _dim,
-	                              const ripser& parent)
+	                              const ripser<compressed_lower_distance_matrix>& parent)
 	    : idx_below(get_index(_simplex)), idx_above(0), v(parent.n - 1), k(_dim + 1),
 	      vertices(_dim + 1), simplex(_simplex), modulus(parent.modulus), dist(parent.dist),
 	      binomial_coeff(parent.binomial_coeff) {
@@ -874,7 +874,7 @@ private:
 
 public:
 	simplex_coboundary_enumerator(const diameter_entry_t _simplex, index_t _dim,
-	                              const ripser& _parent)
+	                              const ripser<sparse_distance_matrix>& _parent)
 	    : parent(_parent), idx_below(get_index(_simplex)), idx_above(0), v(parent.n - 1),
 	      k(_dim + 1), max_vertex_below(parent.n - 1), simplex(_simplex), modulus(parent.modulus),
 	      dist(parent.dist), binomial_coeff(parent.binomial_coeff), vertices(parent.vertices),

--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -859,7 +859,7 @@ public:
 
 template <> class ripser<sparse_distance_matrix>::simplex_coboundary_enumerator {
 private:
-	const ripser& parent;
+	const ripser<sparse_distance_matrix>& parent;
 
 	index_t idx_below, idx_above, v, k, max_vertex_below;
 	const diameter_entry_t simplex;

--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -58,12 +58,6 @@ derivative works thereof, in binary and source code form.
 #endif
 
 
-template <typename DistanceMatrix> class ripser;
-template <> class ripser<compressed_lower_distance_matrix>::simplex_coboundary_enumerator;
-template <> class ripser<sparse_distance_matrix>::simplex_coboundary_enumerator;
-template <> void compressed_distance_matrix<LOWER_TRIANGULAR>::init_rows();
-template <> void compressed_distance_matrix<UPPER_TRIANGULAR>::init_rows();
-
 
 template <class Key, class T> class hash_map : public std::unordered_map<Key, T> {};
 typedef float value_t;
@@ -285,6 +279,14 @@ value_t compressed_distance_matrix<LOWER_TRIANGULAR>::operator()(const index_t i
 
 typedef compressed_distance_matrix<LOWER_TRIANGULAR> compressed_lower_distance_matrix;
 typedef compressed_distance_matrix<UPPER_TRIANGULAR> compressed_upper_distance_matrix;
+
+
+template <typename DistanceMatrix> class ripser;
+template <> class ripser<compressed_lower_distance_matrix>::simplex_coboundary_enumerator;
+template <> class ripser<sparse_distance_matrix>::simplex_coboundary_enumerator;
+template <> void compressed_distance_matrix<LOWER_TRIANGULAR>::init_rows();
+template <> void compressed_distance_matrix<UPPER_TRIANGULAR>::init_rows();
+
 
 
 class union_find {

--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -58,7 +58,6 @@ derivative works thereof, in binary and source code form.
 #endif
 
 
-
 template <class Key, class T> class hash_map : public std::unordered_map<Key, T> {};
 typedef float value_t;
 typedef int64_t index_t;

--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -51,11 +51,11 @@ derivative works thereof, in binary and source code form.
 #include "ripser.hpp"
 
 
-/* Packing support for Windows */
+/* Disable packing for Windows */
 #if defined _WIN32
-#define PACK( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop) )
+#define PACK
 #else
-#define PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))
+#define PACK __attribute__((__packed__))
 #endif
 
 
@@ -108,7 +108,7 @@ std::vector<coefficient_t> multiplicative_inverse_vector(const coefficient_t m) 
 }
 
 #ifdef USE_COEFFICIENTS
-struct entry_t {
+struct PACK entry_t {
 	index_t index : 8 * (sizeof(index_t) - sizeof(coefficient_t));
 	coefficient_t coefficient;
 	entry_t(index_t _index, coefficient_t _coefficient)

--- a/ripser/ripser.hpp
+++ b/ripser/ripser.hpp
@@ -1,0 +1,1 @@
+template <typename DistanceMatrix> class ripser;

--- a/ripser/ripser.hpp
+++ b/ripser/ripser.hpp
@@ -1,1 +1,0 @@
-template <typename DistanceMatrix> class ripser;


### PR DESCRIPTION
With help from @lmcinnes, I specialized the `ripser` class in C++ to fix build problems with Windows.

This PR uses MSVC instead of MINGW on Appveyor, enhancing compatibility with mainstream Windows. This should also make it possible to enable Windows builds via conda-forge.