### PR TITLE
fix to broken API call

### DIFF
--- a/docs/notebooks/Representative Cocycles.ipynb
+++ b/docs/notebooks/Representative Cocycles.ipynb
@@ -123,7 +123,7 @@
     "result = ripser(x, coeff=17, do_cocycles=True)\n",
     "diagrams = result['dgms']\n",
     "cocycles = result['cocycles']\n",
-    "D = result['dm']"
+    "D = result['dperm2all']"
    ]
   },
   {


### PR DESCRIPTION
The key for "distance matrix" had been changed from "dm" to "dperm2all" which broke this tutorial. This is now fixed.