### PR TITLE
Fix #103

### DIFF
--- a/ripser/ripser.py
+++ b/ripser/ripser.py
@@ -299,7 +299,7 @@ def ripser(
         dm = sparse.coo_matrix(dm)
 
     if sparse.issparse(dm):
-        if isspmatrix_coo(dm):
+        if sparse.isspmatrix_coo(dm):
             # If the matrix is already COO, we need to order the row and column indices
             # lexicographically to avoid errors. See issue #103
             row, col, data = dm.row, dm.col, dm.data

--- a/ripser/ripser.py
+++ b/ripser/ripser.py
@@ -299,16 +299,24 @@ def ripser(
         dm = sparse.coo_matrix(dm)
 
     if sparse.issparse(dm):
-        coo = dm.tocoo()
+        if isspmatrix_coo(dm):
+            # If the matrix is already COO, we need to order the row and column indices
+            # lexicographically to avoid errors. See issue #103
+            row, col, data = dm.row, dm.col, dm.data
+            lex_sort_idx = np.lexsort((col, row))
+            row, col, data = row[lex_sort_idx], col[lex_sort_idx], data[lex_sort_idx]
+        else:
+            # Lexicographic ordering is performed by scipy upon conversion to COO
+            coo = dm.tocoo()
+            row, col, data = coo.row, coo.col, coo.data
         res = DRFDMSparse(
-            coo.row.astype(dtype=np.int32, order="C"),
-            coo.col.astype(dtype=np.int32, order="C"),
-            np.array(coo.data, dtype=np.float32, order="C"),
+            row.astype(dtype=np.int32, order="C"),
+            col.astype(dtype=np.int32, order="C"),
+            np.array(data, dtype=np.float32, order="C"),
             n_points,
             maxdim,
             thresh,
             coeff,
-            do_cocycles,
         )
     else:
         I, J = np.meshgrid(np.arange(n_points), np.arange(n_points))


### PR DESCRIPTION
Fixes #103 by enforcing lexicographic ordering of row and column index pairs.

An alternative patch would have been to first convert to e.g. `CSR` and then to `COO` again, making `scipy` do the lexicographic sorting. This latter approach is typically slower, but asymptotically becomes better as the number of entries increases. A more satisfying solution would probably be to intervene on the C++ code.

Ideally, additional unit tests would be added to check output equality between different `scipy` formats. @ctralie let me know if you are planning to do this yourself, or would prefer if I did it.