### PR TITLE
Revert "Merge pull request #104 from ulupo/coo_format_patch"

### DIFF
--- a/ripser/ripser.py
+++ b/ripser/ripser.py
@@ -299,24 +299,16 @@ def ripser(
         dm = sparse.coo_matrix(dm)
 
     if sparse.issparse(dm):
-        if sparse.isspmatrix_coo(dm):
-            # If the matrix is already COO, we need to order the row and column indices
-            # lexicographically to avoid errors. See issue #103
-            row, col, data = dm.row, dm.col, dm.data
-            lex_sort_idx = np.lexsort((col, row))
-            row, col, data = row[lex_sort_idx], col[lex_sort_idx], data[lex_sort_idx]
-        else:
-            # Lexicographic ordering is performed by scipy upon conversion to COO
-            coo = dm.tocoo()
-            row, col, data = coo.row, coo.col, coo.data
+        coo = dm.tocoo()
         res = DRFDMSparse(
-            row.astype(dtype=np.int32, order="C"),
-            col.astype(dtype=np.int32, order="C"),
-            np.array(data, dtype=np.float32, order="C"),
+            coo.row.astype(dtype=np.int32, order="C"),
+            coo.col.astype(dtype=np.int32, order="C"),
+            np.array(coo.data, dtype=np.float32, order="C"),
             n_points,
             maxdim,
             thresh,
             coeff,
+            do_cocycles,
         )
     else:
         I, J = np.meshgrid(np.arange(n_points), np.arange(n_points))


### PR DESCRIPTION
This reverts commit 07adc60c518dbdd59e443c3bd82f1ce8452a5c98.

The up-to-date version of upstream ripser which was integrated in the project by @MonkeyBreaker in #106 does not seem to suffer from the issues pointed out in #103 and addressed by #104. 

It seems that there are no longer wrong outputs when sparse matrices are initialised in non-lexicographic ways. The unit test introduced by @ctralie in 1b565c now serves as a regression test.

It would be nice to have @ubauer's or @MonkeyBreaker's confirmation that my reading of the situation is correct.