### PR TITLE
Use oldest-supported-numpy when building the package.

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           git clone https://github.com/martinus/robin-hood-hashing ripser/robinhood
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine Cython numpy pytest
+          pip install setuptools wheel twine Cython oldest-supported-numpy pytest
           python setup.py install
       - name: Run tests
         run: pytest .
@@ -58,7 +58,7 @@ jobs:
         run: |
           git clone https://github.com/martinus/robin-hood-hashing ripser/robinhood
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine Cython numpy pytest
+          pip install setuptools wheel twine Cython oldest-supported-numpy pytest
           python setup.py install
       - name: Run tests
         run: pytest .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "cython"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython"]


### PR DESCRIPTION
This PR attempts to resolve #128. See issue for details.
