### PR TITLE
Prevents simplex assembly in last dimension

### DIFF
--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -636,8 +636,9 @@ public:
 #endif
                 auto cofacet = cofacets.next();
                 if (get_diameter(cofacet) <= threshold) {
-                    next_simplices.push_back(
-                        {get_diameter(cofacet), get_index(cofacet)});
+                    if (dim != dim_max)
+                        next_simplices.push_back(
+                            {get_diameter(cofacet), get_index(cofacet)});
 
                     if (pivot_column_index.find(get_entry(cofacet)) ==
                         pivot_column_index.end())


### PR DESCRIPTION
This is just a copy of reds-heig/ripser@65225bf4f2ffd0cafccc3acab487f5557544cc56 which has already been submitted as a PR to the "upstream" `ripser` repository as https://github.com/Ripser/ripser/pull/37.

See Figure 6 in [our paper](https://arxiv.org/pdf/2107.05412.pdf) illustrating the impact on memory.