### PR TITLE
Add explicit include for <limits>

### DIFF
--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -47,6 +47,7 @@ derivative works thereof, in binary and source code form.
 #include <iostream>
 #include <iterator>
 #include <numeric>
+#include <limits>
 #include <queue>
 #include <sstream>
 #include <unordered_map>


### PR DESCRIPTION
Fixes compilation for Clang-12 and GCC 11 and up. This explicit is now required of compilers.

See this: https://www.gnu.org/software/gcc/gcc-11/porting_to.html#header-dep-changes