### PR TITLE
Add #include <limits> to avoid build error for some compilers

### DIFF
--- a/ripser/ripser.cpp
+++ b/ripser/ripser.cpp
@@ -46,6 +46,7 @@ derivative works thereof, in binary and source code form.
 #include <iomanip>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <numeric>
 #include <queue>
 #include <sstream>


### PR DESCRIPTION
Some environments, such as Ubuntu 22.04, fail to build ripser.py, as shown in  #142.  This pull request fixes the problem.