### PR TITLE
Fixing AttributeError in drawLineColored function

### DIFF
--- a/docs/notebooks/Representative Cocycles.ipynb
+++ b/docs/notebooks/Representative Cocycles.ipynb
@@ -39,7 +39,7 @@
    "source": [
     "def drawLineColored(X, C):\n",
     "    for i in range(X.shape[0]-1):\n",
-    "        plt.plot(X[i:i+2, 0], X[i:i+2, 1], c=C[i, :], lineWidth = 3)\n",
+    "        plt.plot(X[i:i+2, 0], X[i:i+2, 1], c=C[i, :], linewidth = 3)\n",
     "\n",
     "def plotCocycle2D(D, X, cocycle, thresh):\n",
     "    \"\"\"\n",


### PR DESCRIPTION
Hi scikit-tda team,

I hope this message finds you well. I've encountered an issue while using the `drawLineColored` function in the `ripser.py` file. Specifically, the error "AttributeError: Line2D.set() got an unexpected keyword argument 'lineWidth'" is raised when trying to run the code from the Representative Cocycles notebook available at https://ripser.scikit-tda.org/en/latest/notebooks/Representative%20Cocycles.html.

After investigating, I found that the issue stems from the use of 'lineWidth' with an uppercase 'W' in the `drawLineColored` function:

```python
def drawLineColored(X, C):
    for i in range(X.shape[0]-1):
        plt.plot(X[i:i+2, 0], X[i:i+2, 1], c=C[i, :], lineWidth=3)
```

The correct keyword argument is 'linewidth' with a lowercase 'w'. To address this, I have made the necessary changes to the `drawLineColored` function, replacing 'lineWidth' with 'linewidth'.

I have created a pull request with these changes. Please review it at your earliest convenience.

Thank you for your time and consideration.