### PR TITLE
Fix runners and update code-cov usage

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -23,20 +23,20 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Clone robinhood
         run: |
           git clone https://github.com/martinus/robin-hood-hashing robinhood
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v3.2.0
         env:
-          CIBW_SKIP: "pp* cp36-* cp37-* *win_arm64 *_i686"
+          CIBW_SKIP: "*win_arm64 *_i686"
           CIBW_BUILD_VERBOSITY: 1
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: "pytest {project}/tests"
-          CIBW_TEST_SKIP: "*win32 *musllinux*"
+          CIBW_TEST_SKIP: "*win32 *musllinux* cp314t-*"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -47,7 +47,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Clone robinhood
         run: |
@@ -72,7 +72,7 @@ jobs:
       id-token: write
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           # unpacks all CIBW artifacts into dist/
           pattern: cibw-*

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
-          pytest --cov-report=xml --cov=./
+          pytest --cov-report=xml --cov-report=term --cov=src/ripser
       - name: Upload coverage results
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         uses: codecov/codecov-action@v5
@@ -57,7 +57,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
@@ -82,7 +82,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ class CustomBuildExtCommand(build_ext):
         build_ext.run(self)
 
 
-extra_compile_args = ["-Ofast", "-D_hypot=hypot"]
+extra_compile_args = ["-O3", "-D_hypot=hypot"]
 extra_link_args = []
 
 if platform.system() == "Windows":


### PR DESCRIPTION
The macos runners don't produce valid wheels nor do the conda runs. I think the underlying reason is a compile argument `-Ofast` is deprecated and now defaults to `-O3 -ffast-math` and `ffast-math` does not handle infinities correctly (on macos at least). The conda images were generated on macos runners, so I think this should fix both problems. 

The code coverage CI job could also use a little cleaning up, so we'll use this PR for both.